### PR TITLE
Replaced default watch with gulp-watch

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var browserSync = require('browser-sync');
 var runSequence = require('run-sequence');
 var config = require('../config.js');
+var watch = require('gulp-watch');
 
 gulp.task('watch:js', ['browserify', 'copy:js']);
 gulp.task('watch:img', ['copy:img']);
@@ -10,19 +11,19 @@ gulp.task('watch:twig', ['twig']);
 gulp.task('watch:svg', ['svg2png', 'svgSprite', 'copy:svg']);
 
 gulp.task('watch', ['browser-sync'], function() {
-    gulp.watch(config.src + 'js/**/*', function() {
+    watch(config.src + 'js/**/*', function() {
         runSequence('clean:js', 'watch:js', browserSync.reload);
     });
-    gulp.watch(config.src + 'img/**/*', function() {
+    watch(config.src + 'img/**/*', function() {
         runSequence('clean:img', 'watch:img', browserSync.reload);
     });
-    gulp.watch(config.src + 'sass/**/*', function() {
+    watch(config.src + 'sass/**/*', function() {
         runSequence('clean:sass', 'watch:sass', browserSync.reload);
     });
-    gulp.watch(config.src + 'twig/**/*', function() {
+    watch(config.src + 'twig/**/*', function() {
         runSequence('clean:twig', 'watch:twig', browserSync.reload);
     });
-    gulp.watch(config.src + 'svg/**/*', function() {
+    watch(config.src + 'svg/**/*', function() {
         runSequence('clean:svg', 'watch:svg', browserSync.reload);
     });
 });

--- a/src/twig/views/index.twig
+++ b/src/twig/views/index.twig
@@ -9,7 +9,6 @@
     <h1 class="is-hidden">{{ get_project_name() }}</h1>
 
     {% svg "logo", "300x100" %}
-
     <pre>{{ get_project_name() }} - {{ get_project_version() }}</pre>
     <pre>{{ get_project_description() }}</pre>
     <pre><a href="{{ get_project_repository() }}">{{ get_project_repository() }}</a></pre>


### PR DESCRIPTION
Replaced default gulp watch with gulp-watch to allow watching for new files without having to reload gulp. 
