### PR TITLE
Affichage des erreurs de compilation d'Uglify, comme on le fait pour Browserify.

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -30,6 +30,14 @@ gulp.task('browserify', function() {
             loadMaps: config.sourcemaps
         })))
         .pipe(gulpif(config.minify || argv.prod, uglify()))
+        .on('error', function(error) {
+            notifier.notify({
+                'title': 'Compiling Error: Uglify',
+                'message': error.message.replace('\n', '')
+            });
+            gutil.log(gutil.colors.red('Error: ' + error.message));
+            this.emit('end');
+        })
         .pipe(gulpif(config.sourcemaps && !argv.prod, sourcemaps.write('./')))
         .pipe(gulp.dest(config.build + 'js/'));
 });


### PR DESCRIPTION
J'imagine qu'il y a une façon plus clean d'afficher les erreurs pour toutes les tasks, mais ca fait la job pour moi, alors je vous l'envoie en PR.
